### PR TITLE
feat: add SessionStart hook for remote env setup

### DIFF
--- a/.claude/hooks/setup-remote-env.sh
+++ b/.claude/hooks/setup-remote-env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+NEEDS_SETUP=false
+
+# Install deps if missing
+if [ ! -d "node_modules" ]; then
+  npm install 2>&1
+  NEEDS_SETUP=true
+fi
+
+# Pull env vars if missing
+if [ ! -f ".env.local" ]; then
+  vercel env pull .env.local 2>&1 || echo "Warning: vercel env pull failed - may need auth"
+  NEEDS_SETUP=true
+fi
+
+# Inject env vars into session via CLAUDE_ENV_FILE
+if [ -n "$CLAUDE_ENV_FILE" ] && [ -f ".env.local" ]; then
+  while IFS= read -r line; do
+    [[ "$line" =~ ^#.*$ ]] && continue
+    [[ -z "$line" ]] && continue
+    echo "export $line" >> "$CLAUDE_ENV_FILE"
+  done < .env.local
+fi
+
+if [ "$NEEDS_SETUP" = true ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Remote environment was configured: npm install + env vars pulled."}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-remote-env.sh",
+            "timeout": 120,
+            "statusMessage": "Setting up environment..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `SessionStart` hook that auto-configures remote claude.ai sessions
- Runs `npm install` if `node_modules` is missing
- Runs `vercel env pull .env.local` if `.env.local` is missing
- Injects env vars into the Claude session via `CLAUDE_ENV_FILE`
- No-ops locally when everything is already present

## Test plan
- [ ] Start a new local Claude Code session — hook fires and does nothing
- [ ] Push to repo, start remote session on claude.ai — hook installs deps + pulls env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic environment setup now runs at session start, installing dependencies and configuring environment variables as needed
  * Enhanced foot and bike routing with river crossing detection to intelligently route across bridges

* **Tests**
  * Expanded test coverage for river crossing scenarios and edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->