### PR TITLE
docs: align Strava docs with manual-import reality (#53)

### DIFF
--- a/docs/features/STRAVA_INTEGRATION.md
+++ b/docs/features/STRAVA_INTEGRATION.md
@@ -77,6 +77,21 @@ The available Routes API endpoints are read-only:
 
 See [Strava API Routes Documentation](https://developers.strava.com/docs/reference/#api-Routes) for details.
 
+## June 2026 Strava Developer Program Update
+
+On **June 1, 2026**, Strava emailed developers announcing changes to its API and Developer Program. The key takeaway for Routista: **the announcement introduces no route-creation / write endpoint.** The Routes API remains read-only (Export GPX/TCX, Get Route, List Athlete Routes), so the long-standing blocker for direct route push is unchanged — and there are now *additional* barriers.
+
+| Change | Relevance to Routista |
+| :--- | :--- |
+| **Official Strava MCP** (read your own data, incl. subscriber data) | Read-only — for athletes analyzing their own data. **Not** a route-write/push path. No impact on Routista's "push a planned route" use case. |
+| **New tiers** (Standard / Extended Access) + new API Agreement & Policy | Only relevant if Routista ever uses the API. The manual flow uses no API, so it is unaffected today. |
+| **Standard Tier requires a paid Strava subscription** (active devs get 3 months free) | A future cost/constraint for any direct-integration attempt. |
+| **Intermediary-platform access restricted** | Direct integrations unaffected. Routista's manual flow touches no athlete data — but this rules out any future "route data via a third-party layer" design. |
+| **Club + Segments Explore endpoints deprecated** (Sep 1, 2026) | Routista uses none of these. No impact. |
+| **2027 technical changes** (Jun 1, 2027) | No code impact today (Routista has no API client), but **prerequisites** for any future integration — see below. |
+
+**Conclusion:** Keep the current manual GPX-import flow. Direct route push remains impossible (tracked in issue #22).
+
 ## Historical Context
 
 The original implementation attempted to use OAuth and a `POST /api/v3/routes` endpoint, which:
@@ -92,9 +107,17 @@ The current manual import approach:
 
 ## Future Considerations
 
-If Strava ever opens a public route creation API, the implementation could be updated to:
-1. Re-enable OAuth flow
+If Strava ever opens a public route-creation API, the implementation could be updated to:
+1. Re-enable an OAuth flow
 2. Push routes directly via API
 3. Provide instant "View on Strava" links after upload
 
-For now, the manual import flow provides the best user experience given API limitations.
+Any such future integration **must** be built against the 2027 technical requirements from day one (effective **Jun 1, 2027**):
+
+- **Auth tokens in request headers**, not form/query params.
+- **New base URL**: `https://www.strava.com/api/v3` → `https://www.api-v3.strava.com`.
+- **`oauth/deauthorize` retired** in favor of `oauth/revoke`.
+
+…and within the new program constraints: a **paid Strava subscription** is required for Standard-Tier developers, and **intermediary-platform access is banned** (no routing route data through a third-party layer).
+
+For now, the manual import flow provides the best user experience given these limitations.

--- a/docs/technical/CONTEXT_MAP.md
+++ b/docs/technical/CONTEXT_MAP.md
@@ -16,7 +16,7 @@ This file maps concepts and features to their source of truth in the codebase. U
 | **Area Selection** | `src/components/AreaSelector.tsx` | Map interface for choosing center point and radius. |
 | **GPX Export** | `src/lib/gpxGenerator.ts` | Converts Route data to GPX XML format. |
 | **Social Sharing** | `src/components/ShareModal.tsx`, `src/lib/shareImageGenerator.ts` | Branded image generation for social media. See `docs/features/SHARE.md`. |
-| **Strava Integration** | `src/components/StravaButton.tsx`, `src/lib/stravaService.ts`, `src/app/api/strava/` | Direct route upload to Strava. **Currently disabled** pending Routes API access. Debug instrumentation in place (Issue #44). See `docs/features/STRAVA_INTEGRATION.md`. |
+| **Strava Integration** | `src/components/StravaButton.tsx`, `src/lib/gpxGenerator.ts`, `tests/components/StravaButton.test.tsx` | **Enabled — manual GPX import.** Downloads a GPX and opens Strava's route-import page (no OAuth/API; direct route push remains impossible, see #22). See `docs/features/STRAVA_INTEGRATION.md`. |
 | **Route Caching** | `src/lib/radarService.ts` | Caches routes in Upstash Redis (24h TTL). |
 | **Rate Limiting** | `middleware.ts`, `src/lib/rateLimit.ts` | IP-based rate limiting (10 req/min) using Upstash Redis. |
 | **Error Tracking** | `sentry.*.config.ts`, `src/app/global-error.tsx` | Sentry SDK for client/server/edge error capture. |
@@ -51,7 +51,6 @@ This file maps concepts and features to their source of truth in the codebase. U
 *   `imageProcessing.ts`: **CRITICAL**. Browser wrapper for image processing (uses Canvas API + core).
 *   `gpxGenerator.ts`: Utility for file export.
 *   `shareImageGenerator.ts`: Branded image generation for social sharing. Uses `leaflet-image` + Canvas API.
-*   `stravaService.ts`: Strava OAuth and API integration. Token management, route upload.
 *   `analytics.ts`: Type-safe PostHog analytics wrapper. See Analytics Events below.
 
 ### Infrastructure (root)
@@ -77,7 +76,6 @@ This file maps concepts and features to their source of truth in the codebase. U
     *   `gpxGenerator.test.ts`: GPX XML generation tests.
     *   `geoUtils.test.ts`: Distance, route length, simplification tests.
     *   `imageProcessingCore.test.ts`: Otsu algorithm, boundary tracing tests.
-    *   `stravaService.test.ts`: Strava mode mapping tests.
     *   `shareImageGenerator.test.ts`: Mobile detection, platform URL tests.
     *   `radarService.test.ts`: Coordinate hashing tests.
     *   `rateLimit.test.ts`: Rate limiting logic tests.
@@ -88,12 +86,10 @@ This file maps concepts and features to their source of truth in the codebase. U
     *   `ImageUpload.test.tsx`: File upload, drag-drop, preview tests.
     *   `ModeSelector.test.tsx`: Transport mode selection tests.
     *   `ShareModal.test.tsx`: Social sharing modal tests.
-    *   `StravaButton.test.tsx`: Strava OAuth and upload tests.
+    *   `StravaButton.test.tsx`: Manual export flow tests (GPX download + opens Strava import page).
 *   `api/`: API route tests.
     *   `radar-autocomplete.test.ts`: Autocomplete endpoint tests.
     *   `radar-directions.test.ts`: Directions endpoint tests.
-    *   `strava-callback.test.ts`: OAuth callback tests.
-    *   `strava-upload.test.ts`: Route upload tests.
 *   `utils/nodeImageProcessing.ts`: Node.js wrapper for image processing (uses Sharp + core).
 *   `e2e/`: E2E test templates.
 
@@ -104,7 +100,7 @@ This file maps concepts and features to their source of truth in the codebase. U
 *   `ResultMap.tsx`: Final output display. Exposes `getMap()` ref for sharing.
 *   `ModeSelector.tsx`: Walking/Cycling/Driving cards. Used in variant A only.
 *   `ShareModal.tsx`: Social sharing UI. Platform selection, copy/download/share actions.
-*   `StravaButton.tsx`: Strava connect/upload button. OAuth popup flow, upload status.
+*   `StravaButton.tsx`: Export-to-Strava button. Manual flow: downloads GPX + opens Strava's route-import page.
 *   `ABTestProvider.tsx`: UI variant context provider. See `docs/features/UI_VARIANTS.md`.
 *   `SupportButton.tsx`: Buy Me a Coffee button with analytics tracking.
 
@@ -167,7 +163,7 @@ User-facing feature descriptions with implementation details:
 | `ROUTE_GENERATION.md` | Shape-to-route matching algorithm |
 | `ROUTE_EXPORT.md` | GPX download functionality |
 | `SHARE.md` | Social media sharing |
-| `STRAVA_INTEGRATION.md` | Direct Strava route upload |
+| `STRAVA_INTEGRATION.md` | Strava export via manual GPX import |
 | `UI_VARIANTS.md` | A/B test variants configuration |
 
 ### Technical Documentation (`docs/technical/`)

--- a/docs/technical/TESTING_STRATEGY.md
+++ b/docs/technical/TESTING_STRATEGY.md
@@ -78,7 +78,6 @@ We follow the test pyramid approach, with more tests at the bottom (unit) and fe
 | `rateLimit.test.ts` | Rate-limiting logic |
 | `routeGenerator.test.ts` | Route generation client |
 | `shareImageGenerator.test.ts` | Share functionality |
-| `stravaService.test.ts` | Strava integration |
 | `utils.test.ts` | Utility functions |
 
 ---
@@ -108,7 +107,7 @@ We follow the test pyramid approach, with more tests at the bottom (unit) and fe
 | `ImageUpload.test.tsx` | 97% | Dropzone, file handling, preview, drag-drop, keyboard a11y |
 | `ModeSelector.test.tsx` | 100% | Mode selection, selected state styling |
 | `ShareModal.test.tsx` | 82% | Platform selection, copy/download, close behavior |
-| `StravaButton.test.tsx` | 81% | OAuth flow, upload, error handling, states |
+| `StravaButton.test.tsx` | 81% | Manual export flow (GPX download + opens Strava import page), error handling, states |
 
 **Priority components (remaining):**
 
@@ -145,7 +144,7 @@ export default defineConfig({
 **Characteristics:**
 - Test request validation
 - Test error responses
-- Mock external APIs (Radar, Strava)
+- Mock external APIs (Radar)
 - Verify rate limiting behavior
 
 **What to test:**
@@ -154,8 +153,6 @@ export default defineConfig({
 |-------|------------|
 | `/api/radar/directions` | Coordinate validation, chunking, error propagation |
 | `/api/radar/autocomplete` | Query validation, empty results |
-| `/api/strava/callback` | OAuth exchange, token storage, error handling |
-| `/api/strava/upload` | GPX validation, upload flow, error states |
 
 **Testing pattern:**
 ```typescript
@@ -201,7 +198,7 @@ describe('/api/radar/directions', () => {
 |---------|-------|
 | **Create route from image** | Navigate → Load image → Select area → Choose mode → Generate → Download |
 | **Create route from example** | Navigate → Select example → Generate |
-| **Strava integration** | Connect → Upload route |
+| **Strava export** | Generate route → Export to Strava → GPX downloaded + import page opens |
 | **Mobile flow** | Resize viewport → Complete flow |
 
 ---

--- a/src/components/StravaButton.tsx
+++ b/src/components/StravaButton.tsx
@@ -62,11 +62,9 @@ export function StravaButton({ routeData, className = '' }: StravaButtonProps) {
   // Handle export button click
   const handleExport = useCallback(() => {
     if (!routeData) {
-      console.error('[StravaButton] No route data available');
       return;
     }
 
-    console.log('[StravaButton] Starting export to Strava...');
     setState('processing');
     setErrorMessage(null);
 
@@ -74,11 +72,9 @@ export function StravaButton({ routeData, className = '' }: StravaButtonProps) {
       // Generate and download GPX
       const gpx = generateGPX(routeData);
       downloadGPX(gpx, 'routista-route.gpx');
-      console.log('[StravaButton] GPX file downloaded');
 
       // Open Strava import page in new tab
       window.open(STRAVA_IMPORT_URL, '_blank', 'noopener,noreferrer');
-      console.log('[StravaButton] Opened Strava import page');
 
       // Show instruction message
       setShowInstruction(true);


### PR DESCRIPTION
Closes #53.

## Context
On **June 1, 2026** Strava announced changes to its API and Developer Program. The key finding: **no route-creation / write endpoint** was introduced — the Routes API stays read-only, so direct route push (#22) remains blocked, with new barriers added. This issue is about **documentation accuracy + forward-looking constraints**, not a feature.

The docs referenced an OAuth/API implementation that no longer exists (it was removed in #45 when we switched to the manual GPX-import flow).

## Changes
- **`docs/features/STRAVA_INTEGRATION.md`**: new "June 2026 Strava Developer Program Update" section (no write endpoint; official Strava MCP is read-only; subscription + intermediary-ban barriers); documented the 2027 technical prerequisites (header auth, `api-v3.strava.com` base URL, `oauth/revoke`).
- **`docs/technical/CONTEXT_MAP.md`**: removed refs to non-existent `stravaService.ts`, `src/app/api/strava/`, and phantom tests; status corrected to **"enabled — manual GPX import"**; fixed component/test descriptions.
- **`docs/technical/TESTING_STRATEGY.md`**: dropped stale `stravaService.test.ts` / `strava-callback` / `strava-upload` entries; updated `StravaButton` coverage description and the E2E journey to the manual export flow.
- **`src/components/StravaButton.tsx`**: stripped leftover happy-path `console.log`/`console.error` noise (the only real residual of #44's "remove debug instrumentation" intent — the OAuth/API code was already removed in #45). Kept the catch-block error log. **No behavior change.**

## Verified
- No hardcoded `strava.com/api/v3` URLs or form-param token usage anywhere in `src/` (no 2027 migration needed today).
- `docs/` grep clean of stale Strava paths.
- `npm run lint`, `npx tsc --noEmit` clean; **301 tests pass** (2 pre-existing skips).
- Lockfile untouched (no dependency changes).

## Follow-up issue actions (done alongside this PR)
- #22: commented that June 2026 does **not** unblock it; added new constraints to acceptance criteria.
- #44: premise moot (instrumentation already gone in #45, write API indefinitely blocked) — closed as not-planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)