### PR TITLE
ci: add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # npm dependencies (root project)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
+    groups:
+      # Bundle all minor + patch bumps into one PR; majors stay separate.
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to automate dependency updates, feeding them through the existing PR/CI pipeline (security workflow, CodeRabbit, SonarCloud gate).

## Config

- **npm** (root `package.json` / `package-lock.json`) — weekly checks (Monday), minor/patch grouped into one PR, majors separate. Commit prefixes `fix(deps)` / `chore(deps)`.
- **github-actions** (workflows in `.github/workflows/`) — weekly checks, grouped, `ci` prefix.

## Notes

- Grouping keeps PR/CI noise low: one combined PR per ecosystem for minor+patch bumps; breaking major bumps reviewed individually.
- `open-pull-requests-limit: 5` for npm.
- No `reviewers` field — CodeRabbit + required CI already gate every PR.
- **Manual follow-up:** enable **Dependabot security updates** in repo Settings → Code security for automatic vulnerability-fix PRs (not configurable via this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for automated dependency updates with weekly scheduling for npm packages and GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->