### PR TITLE
docs: document VERCEL_AUTOMATION_BYPASS_SECRET in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,25 @@ NEXT_PUBLIC_SENTRY_DSN=https://your-public-key@sentry.io/your-project-id
 SENTRY_AUTH_TOKEN=your-sentry-auth-token
 SENTRY_ORG=your-sentry-org
 SENTRY_PROJECT=your-sentry-project
+
+# ============================================
+# Vercel Protection Bypass (for testing preview deployments)
+# ============================================
+# Preview deployments sit behind Vercel's SSO wall (ssoProtection is set to
+# all_except_custom_domains), so every preview URL redirects to vercel.com/sso-api
+# and no script or browser automation can reach one. Only the custom domain
+# (www.routista.eu) is publicly reachable.
+#
+# This secret lets automated requests skip that wall. Not needed for local dev —
+# only for hitting preview URLs from tests, scripts or CI.
+#
+# Create at: Vercel → routista → Settings → Deployment Protection
+#            → Protection Bypass for Automation
+# Vercel injects the same variable name into deployments, so local and deployed
+# environments stay consistent.
+#
+# Send it as a header on every request to a preview:
+#   curl -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+#        https://routista-git-<branch>-jakubanderwalds-projects.vercel.app/en
+# Add "x-vercel-set-bypass-cookie: true" to persist it across a browser session.
+VERCEL_AUTOMATION_BYPASS_SECRET=your-32-char-alphanumeric-bypass-secret


### PR DESCRIPTION
## Why

Preview deployments sit behind Vercel's SSO wall (`ssoProtection: all_except_custom_domains`), so every preview URL redirects to `vercel.com/sso-api`. Nothing automated — tests, scripts, CI — can reach a preview without a Protection Bypass for Automation secret. Only the custom domain is publicly reachable.

That requirement was undocumented and discoverable only by hitting the wall.

## What

Adds `VERCEL_AUTOMATION_BYPASS_SECRET` to `.env.example` with where to create it and how to send it. Not needed for local dev — only for reaching preview URLs.

The variable name matches what Vercel injects into deployments, so local and deployed environments stay consistent.

Placeholder value only; the real secret lives in gitignored `.env.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional Vercel preview deployment protection bypass configuration.
  * Added guidance for supplying the bypass secret through request headers and optionally setting a bypass cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->