### PR TITLE
docs: document the deployment e2e suite; gitignore per-machine Claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ test_output*.txt
 # that churn every session. A shared .claude/settings.json stays committable.
 .claude/settings.local.json
 .claude/*.lock
+
+# e2e run artifacts (screenshots written beside the scripts)
+tests/e2e/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ test_output*.txt
 
 # worktrees (kept inside workspace to avoid Cursor "outside workspace" prompts)
 /.worktrees/
+
+# claude code — per-machine only. settings.local.json is the personal permission
+# allowlist (contains absolute paths), and the lock files are runtime artifacts
+# that churn every session. A shared .claude/settings.json stays committable.
+.claude/settings.local.json
+.claude/*.lock

--- a/docs/technical/AUTOMATED_TESTING.md
+++ b/docs/technical/AUTOMATED_TESTING.md
@@ -1,0 +1,146 @@
+# Automated Testing Against Deployments
+
+How to run browser-driven checks against a **deployed** Routista environment — a Vercel
+preview or production — as opposed to the unit and component tests that run in CI.
+
+For the overall test pyramid, coverage targets and unit/integration guidance, see
+[TESTING_STRATEGY.md](./TESTING_STRATEGY.md). This document covers Layer 4 only.
+
+## Why this exists
+
+CI (`.github/workflows/security.yml`) runs audit, lint, and the vitest suite against the
+source. None of that exercises a real browser, so a class of failure slips through:
+
+- an icon package drops an export and the glyph silently vanishes
+- a React or Leaflet upgrade breaks hydration only in a real browser
+- a route builds fine but throws at runtime
+
+That class is exactly what dependency bumps produce. These scripts catch it by driving a
+real Chromium against a deployment.
+
+## Prerequisites
+
+### Playwright (installed on demand, not a dependency)
+
+Playwright is deliberately **not** in `package.json`. It is a large dependency and these
+scripts are run manually, so adding it would slow every `npm ci` in CI for something CI
+does not run. Install it when you need it:
+
+```bash
+npm i -D playwright
+npx playwright install chromium
+```
+
+Remember to drop it from `package.json` afterwards (`npm un -D playwright`) — the browser
+download stays cached in `~/Library/Caches/ms-playwright`, so reinstalling later is quick.
+
+If you would rather not touch `package.json` at all, install into a scratch directory and
+symlink it in. Note that `NODE_PATH` does **not** work here: these are ES modules, and ESM
+resolves bare specifiers by walking up from the importing file, ignoring `NODE_PATH`
+entirely.
+
+```bash
+mkdir -p /tmp/pw && (cd /tmp/pw && npm i playwright && npx playwright install chromium)
+ln -sfn /tmp/pw/node_modules/playwright      node_modules/playwright
+ln -sfn /tmp/pw/node_modules/playwright-core node_modules/playwright-core
+```
+
+> If these checks ever move into CI, Playwright should become a real devDependency and
+> the install should be cached — see *Wiring into CI* below.
+
+### The preview bypass secret
+
+Preview deployments sit behind Vercel's SSO wall (`ssoProtection` is
+`all_except_custom_domains`), so every preview URL redirects to `vercel.com/sso-api` and
+is unreachable to any script. Only the custom domain (`www.routista.eu`) is public.
+
+Set `VERCEL_AUTOMATION_BYPASS_SECRET` in `.env.local` — see `.env.example` for where to
+create it. Both scripts read it from there, or from the environment if set. **Production
+needs no secret**, so you can run against `https://www.routista.eu` with no setup.
+
+## The scripts
+
+### `tests/e2e/preview-smoke.mjs`
+
+Fast, no external quota. Run it on any change.
+
+```bash
+node tests/e2e/preview-smoke.mjs https://www.routista.eu baseline
+node tests/e2e/preview-smoke.mjs https://routista-git-<branch>-jakubanderwalds-projects.vercel.app my-pr
+```
+
+26 checks. For `/en`, `/en/about` and `/en/create`: HTTP 200, no visible error boundary,
+non-trivial rendered content, no page exceptions, no console errors, and at least one
+`<svg>`. Then it drives the create wizard — loads a test image, waits for shape
+extraction, advances to step 2, and confirms Leaflet mounts — and makes one
+`POST /api/radar/directions` call. Screenshots land beside the script.
+
+Exit code 0 or 1, so it works as a merge gate.
+
+### `tests/e2e/preview-share-flow.mjs`
+
+Slower, and it **consumes Radar quota** by generating a real route. Run it on changes to
+the route pipeline, the share flow, or icons.
+
+```bash
+node tests/e2e/preview-share-flow.mjs https://www.routista.eu
+```
+
+Drives the full journey to a generated route, opens the share modal, and asserts the four
+brand icons render with correct geometry and child-shape counts.
+
+Those assertions are load-bearing: lucide-react v1 removed its brand marks, so Facebook,
+Github, Instagram and Twitter now ship from `src/components/icons/BrandIcons.tsx`. A
+missing icon fails *silently* — the element renders at zero size rather than throwing — so
+presence alone proves nothing and geometry is asserted too.
+
+## How the scripts drive the app
+
+`CreateClient.tsx` renders a hidden `display:none` test-controls block that these scripts
+depend on. Keep it in sync when the wizard changes.
+
+| Hook | Purpose |
+|------|---------|
+| `test-load-star`, `test-load-heart`, `test-load-circle`, … | Load a bundled image without the OS file picker |
+| `current-step` | Current wizard step |
+| `has-image`, `has-shape-points`, `has-route` | Pipeline state probes |
+| `selected-mode`, `ui-variant` | Selected transport mode, A/B variant |
+
+Because the block is `display:none`, Playwright's `click()` refuses to act on it. Dispatch
+the click directly instead:
+
+```js
+await page.locator('[data-testid="test-load-star"]').evaluate((el) => el.click());
+```
+
+## Two traps worth knowing
+
+Both of these produced false failures during development, and both were caught only by
+running the suite against **production** first to establish a known-good baseline. Do that
+before trusting any new assertion.
+
+1. **Next.js embeds its 404 template in the RSC flight payload of every healthy page.**
+   Searching raw `page.content()` for "This page could not be found" therefore fails on
+   every route. Match against visible `innerText` instead.
+
+2. **Leaflet only mounts from wizard step 2 onward.** Asserting `.leaflet-container` on a
+   freshly loaded `/en/create` always fails — the map genuinely is not there yet.
+
+## Wiring into CI
+
+Not wired in today, and the honest trade-off is: these need a deployed URL, so they can
+only run *after* Vercel finishes, which means a `workflow_run` or `deployment_status`
+trigger rather than the normal PR job. Doing it properly means making Playwright a real
+devDependency, caching the browser download, and putting
+`VERCEL_AUTOMATION_BYPASS_SECRET` into repository secrets.
+
+Until then, run them manually before merging anything that touches rendering, the route
+pipeline, or dependencies.
+
+## Relationship to `christmas-shapes.test.ts`
+
+`tests/e2e/christmas-shapes.test.ts` is an older template whose assertions are all
+commented out — it documents an intended flow but asserts nothing, and vitest collects it
+as an empty pass. The `.mjs` scripts here are the working implementation of that idea. The
+template is left in place as a description of the Christmas-shape journeys, which the
+scripts do not yet cover.

--- a/docs/technical/TESTING_STRATEGY.md
+++ b/docs/technical/TESTING_STRATEGY.md
@@ -173,17 +173,25 @@ describe('/api/radar/directions', () => {
 
 ---
 
-### Layer 4: E2E Tests (Cursor Browser)
+### Layer 4: E2E Tests
 
 **Purpose:** Verify critical user journeys work end-to-end.
 
-**Tool:** Cursor's built-in browser MCP tools (not Playwright/Puppeteer)
+Two complementary approaches:
+
+| Approach | Target | When |
+|----------|--------|------|
+| **Scripted** — `tests/e2e/*.mjs` (Playwright) | A deployed Vercel preview or production | Dependency bumps, rendering changes, before merge |
+| **Interactive** — Cursor's browser MCP tools | Local dev server | Exploratory checks, new journeys |
+
+The scripted suite is documented in [AUTOMATED_TESTING.md](./AUTOMATED_TESTING.md) — it
+catches the class of failure CI cannot see, where a page builds cleanly but breaks in a
+real browser. Playwright is intentionally not a devDependency; see that document.
 
 **Characteristics:**
-- Test against running dev server
 - Use `data-testid` attributes for element selection
-- Use `window.__routistaTestHelpers` for image loading
-- Manual execution via Cursor agent
+- Drive the hidden test-controls block in `CreateClient.tsx` to load images without the OS file picker
+- Scripted suite runs against a URL and exits 0/1; interactive runs are manual
 
 **Available Cursor browser tools:**
 - `browser_navigate` - Navigate to URL

--- a/tests/e2e/preview-share-flow.mjs
+++ b/tests/e2e/preview-share-flow.mjs
@@ -1,0 +1,119 @@
+/**
+ * Full journey: image -> shape -> area -> generated route -> share modal.
+ *
+ * Usage:
+ *   node tests/e2e/preview-share-flow.mjs <baseUrl>
+ *
+ * Goes deeper than preview-smoke.mjs: it actually generates a route (hitting the
+ * Radar API) and opens the share modal, which is the only way to reach the brand
+ * icons. Slower and it consumes Radar quota, so run it on changes that touch the
+ * route pipeline, icons, or the share flow — not on every push.
+ *
+ * The brand-icon assertions exist because lucide-react v1 removed its brand marks
+ * (Facebook, Github, Instagram, Twitter). We now ship those glyphs ourselves in
+ * src/components/icons/BrandIcons.tsx, and a missing icon fails silently — the
+ * element renders with zero size rather than throwing — so geometry is asserted,
+ * not just presence.
+ *
+ * See docs/technical/AUTOMATED_TESTING.md. Exits 0 on success, 1 on failure.
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+    console.error('usage: node tests/e2e/preview-share-flow.mjs <baseUrl>');
+    process.exit(1);
+}
+
+function bypassSecret() {
+    if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) return process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    try {
+        const line = readFileSync(join(REPO_ROOT, '.env.local'), 'utf8')
+            .split('\n')
+            .find((l) => l.startsWith('VERCEL_AUTOMATION_BYPASS_SECRET='));
+        if (line) return line.slice('VERCEL_AUTOMATION_BYPASS_SECRET='.length).trim();
+    } catch {
+        /* production needs no bypass */
+    }
+    return '';
+}
+
+const secret = bypassSecret();
+const browser = await chromium.launch();
+const context = await browser.newContext({
+    extraHTTPHeaders: secret
+        ? { 'x-vercel-protection-bypass': secret, 'x-vercel-set-bypass-cookie': 'true' }
+        : {},
+    viewport: { width: 1280, height: 900 },
+});
+const page = await context.newPage();
+let bad = 0;
+
+// --- Github, rendered on the about page ---------------------------------------
+await page.goto(baseUrl + '/en/about', { waitUntil: 'networkidle' });
+const gh = page.locator('svg.lucide-github');
+const ghCount = await gh.count();
+console.log(`about: svg.lucide-github count = ${ghCount}`);
+if (ghCount < 1) {
+    console.log('  FAIL github icon missing');
+    bad++;
+} else {
+    const box = await gh.first().boundingBox();
+    const paths = await gh.first().locator('path').count();
+    console.log(`  box=${box ? `${Math.round(box.width)}x${Math.round(box.height)}` : 'none'} paths=${paths}`);
+    if (!box || box.width < 4 || box.height < 4) {
+        console.log('  FAIL github icon has no size');
+        bad++;
+    }
+    if (paths !== 2) {
+        console.log(`  FAIL github expected 2 paths, got ${paths}`);
+        bad++;
+    }
+}
+
+// --- Drive the wizard all the way to a generated route -------------------------
+await page.goto(baseUrl + '/en/create', { waitUntil: 'networkidle' });
+await page.locator('[data-testid="test-load-star"]').evaluate((el) => el.click());
+await page.waitForFunction(
+    () => document.querySelector('[data-testid="has-shape-points"]')?.textContent?.trim() === 'true',
+    { timeout: 30000 },
+);
+await page.locator('[data-testid="upload-next-button"]').click();
+await page.waitForSelector('.leaflet-container', { timeout: 30000 });
+
+await page.getByRole('button', { name: /generate route/i }).click();
+await page.waitForFunction(
+    () => document.querySelector('[data-testid="has-route"]')?.textContent?.trim() === 'true',
+    { timeout: 120000 },
+);
+console.log('create: route generated');
+
+// --- Instagram / Facebook / Twitter, inside the share modal --------------------
+await page.locator('[data-testid="result-share-button"]').click();
+await page.waitForSelector('[data-testid="share-platform-instagram"]', { timeout: 20000 });
+
+// Expected child-shape counts come from the original lucide paths preserved in
+// BrandIcons.tsx: instagram is rect + path + line, the other two a single path.
+for (const [slug, expectedShapes] of [['instagram', 3], ['facebook', 1], ['twitter', 1]]) {
+    const icon = page.locator(`[data-testid="share-platform-${slug}"] svg.lucide-${slug}`);
+    const n = await icon.count();
+    const box = n ? await icon.first().boundingBox() : null;
+    const shapes = n ? await icon.first().locator('path, rect, line').count() : 0;
+    const ok = n >= 1 && box && box.width > 4 && shapes === expectedShapes;
+    console.log(
+        `share ${slug}: count=${n} box=${box ? `${Math.round(box.width)}x${Math.round(box.height)}` : 'none'} shapes=${shapes} -> ${ok ? 'OK' : 'FAIL'}`,
+    );
+    if (!ok) bad++;
+}
+await page.screenshot({ path: join(HERE, 'share-flow.png') });
+
+await browser.close();
+console.log(bad === 0 ? '\nFull share flow OK, all brand icons render.' : `\n${bad} problems.`);
+process.exit(bad === 0 ? 0 : 1);

--- a/tests/e2e/preview-smoke.mjs
+++ b/tests/e2e/preview-smoke.mjs
@@ -1,0 +1,202 @@
+/**
+ * Smoke suite for a deployed Routista environment (Vercel preview or production).
+ *
+ * Usage:
+ *   node tests/e2e/preview-smoke.mjs <baseUrl> [label]
+ *
+ * See docs/technical/AUTOMATED_TESTING.md for setup and the reasoning behind the
+ * assertions. Requires Playwright — deliberately NOT a devDependency, install on
+ * demand: npm i -D playwright && npx playwright install chromium
+ *
+ * Preview deployments are behind Vercel's SSO wall, so this reads
+ * VERCEL_AUTOMATION_BYPASS_SECRET from .env.local (or the environment) and sends it
+ * as x-vercel-protection-bypass. Production needs no secret.
+ *
+ * Exits 0 when every check passes, 1 otherwise — usable as a merge gate.
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+
+const baseUrl = process.argv[2];
+const label = process.argv[3] || 'run';
+if (!baseUrl) {
+    console.error('usage: node tests/e2e/preview-smoke.mjs <baseUrl> [label]');
+    process.exit(1);
+}
+
+/** Env wins over .env.local so CI can inject the secret without a file. */
+function bypassSecret() {
+    if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) return process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    try {
+        const line = readFileSync(join(REPO_ROOT, '.env.local'), 'utf8')
+            .split('\n')
+            .find((l) => l.startsWith('VERCEL_AUTOMATION_BYPASS_SECRET='));
+        if (line) return line.slice('VERCEL_AUTOMATION_BYPASS_SECRET='.length).trim();
+    } catch {
+        /* production needs no bypass */
+    }
+    return '';
+}
+
+const secret = bypassSecret();
+const headers = secret
+    ? { 'x-vercel-protection-bypass': secret, 'x-vercel-set-bypass-cookie': 'true' }
+    : {};
+
+const failures = [];
+let passCount = 0;
+function check(ok, name, detail = '') {
+    if (ok) {
+        passCount++;
+        console.log(`  PASS  ${name}`);
+    } else {
+        failures.push(`${name}${detail ? ` — ${detail}` : ''}`);
+        console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+    }
+}
+
+/**
+ * Matched against *visible* text only. Next.js embeds its 404 template inside the
+ * serialized RSC flight payload of every healthy page, so matching raw HTML reports
+ * a false failure on every route — confirmed against production.
+ */
+const ERROR_MARKERS = [
+    'application error',
+    'this page could not be found',
+    'internal server error',
+    'something went wrong',
+];
+
+/** Analytics beacons are blocked or noisy on previews; not app regressions. */
+const IGNORED_ERRORS = /posthog|sentry|speed-insights|vitals|_vercel\/insights|favicon|net::ERR_BLOCKED/i;
+
+function watch(page, sink) {
+    page.on('console', (m) => {
+        if (m.type() === 'error' && !IGNORED_ERRORS.test(m.text())) sink.console.push(m.text());
+    });
+    page.on('pageerror', (e) => {
+        if (!IGNORED_ERRORS.test(e.message)) sink.page.push(e.message);
+    });
+}
+
+const probe = (page, id) =>
+    page.locator(`[data-testid="${id}"]`).evaluate((el) => el.textContent?.trim());
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ extraHTTPHeaders: headers, viewport: { width: 1280, height: 900 } });
+
+console.log(`\n=== routista preview smoke: ${label} ===`);
+console.log(`base: ${baseUrl}\n`);
+
+for (const route of [
+    { path: '/en', name: 'home' },
+    { path: '/en/about', name: 'about' },
+    { path: '/en/create', name: 'create' },
+]) {
+    console.log(`- ${route.path}`);
+    const page = await context.newPage();
+    const errs = { console: [], page: [] };
+    watch(page, errs);
+
+    let resp;
+    try {
+        resp = await page.goto(baseUrl + route.path, { waitUntil: 'networkidle', timeout: 60000 });
+    } catch (err) {
+        check(false, `${route.name}: navigation`, err.message);
+        await page.close();
+        continue;
+    }
+
+    check(resp?.status() === 200, `${route.name}: HTTP 200`, `got ${resp?.status()}`);
+
+    const text = (await page.locator('body').innerText()).toLowerCase();
+    const marker = ERROR_MARKERS.find((m) => text.includes(m));
+    check(!marker, `${route.name}: no error boundary`, marker ? `visible "${marker}"` : '');
+    check(text.length > 100, `${route.name}: renders content`, `${text.length} chars visible`);
+    check(errs.page.length === 0, `${route.name}: no page exceptions`, errs.page.slice(0, 3).join(' | '));
+    check(errs.console.length === 0, `${route.name}: no console errors`, errs.console.slice(0, 3).join(' | '));
+
+    // Guards the failure mode where an icon package drops an export: the glyph
+    // silently disappears rather than throwing.
+    const svgCount = await page.locator('svg').count();
+    check(svgCount > 0, `${route.name}: icons render as svg`, `found ${svgCount}`);
+
+    await page.close();
+}
+
+console.log('\n- create wizard: upload -> shape -> area (map)');
+{
+    const page = await context.newPage();
+    const errs = { console: [], page: [] };
+    watch(page, errs);
+
+    try {
+        await page.goto(baseUrl + '/en/create', { waitUntil: 'networkidle', timeout: 60000 });
+        check((await probe(page, 'current-step')) === 'upload', 'wizard: starts at upload step');
+
+        // Test controls live in a display:none div, so a real click is impossible —
+        // dispatch directly, which is how CreateClient.tsx intends them to be driven.
+        await page.locator('[data-testid="test-load-star"]').evaluate((el) => el.click());
+
+        await page.waitForFunction(
+            () => document.querySelector('[data-testid="has-image"]')?.textContent?.trim() === 'true',
+            { timeout: 30000 },
+        );
+        check(true, 'wizard: test image loads');
+
+        await page.waitForFunction(
+            () => document.querySelector('[data-testid="has-shape-points"]')?.textContent?.trim() === 'true',
+            { timeout: 30000 },
+        );
+        check(true, 'wizard: shape extraction produces points');
+
+        await page.locator('[data-testid="upload-next-button"]').click({ timeout: 15000 });
+        await page.waitForFunction(
+            () => document.querySelector('[data-testid="current-step"]')?.textContent?.trim() !== 'upload',
+            { timeout: 15000 },
+        );
+        check(true, `wizard: advances past upload (now "${await probe(page, 'current-step')}")`);
+
+        // Leaflet only mounts from step 2 onward — legitimately absent on step 1.
+        await page.waitForSelector('.leaflet-container', { timeout: 30000 });
+        check(true, 'wizard: leaflet map initialises');
+
+        await page.waitForTimeout(2000);
+        await page.screenshot({ path: join(HERE, `preview-${label}-wizard.png`) });
+    } catch (err) {
+        check(false, 'wizard: full flow', err.message.split('\n')[0]);
+        await page.screenshot({ path: join(HERE, `preview-${label}-wizard-FAILED.png`) }).catch(() => {});
+    }
+
+    check(errs.page.length === 0, 'wizard: no page exceptions', errs.page.slice(0, 3).join(' | '));
+    check(errs.console.length === 0, 'wizard: no console errors', errs.console.slice(0, 3).join(' | '));
+    await page.close();
+}
+
+// One call only — vitest.config.ts already notes Radar rate limiting.
+console.log('\n- POST /api/radar/directions');
+try {
+    const r = await context.request.post(`${baseUrl}/api/radar/directions`, {
+        data: { coordinates: [[13.405, 52.52], [13.41, 52.525]], mode: 'foot' },
+        timeout: 45000,
+    });
+    check(r.status() < 500, 'api: directions not 5xx', `status ${r.status()}`);
+} catch (err) {
+    check(false, 'api: directions reachable', err.message.split('\n')[0]);
+}
+
+await browser.close();
+
+console.log(`\n=== ${passCount} passed, ${failures.length} failed ===`);
+if (failures.length) {
+    console.log('\nFAILURES:');
+    failures.forEach((f) => console.log(`  - ${f}`));
+    process.exit(1);
+}
+console.log('All checks passed.\n');


### PR DESCRIPTION
## Why

Two bits of housekeeping surfaced while clearing the Dependabot backlog.

**1. The e2e suite was undocumented and unshipped.** A Playwright suite was written to gate those eight merges — it caught the lucide-react brand-icon regression concretely rather than by inference — but it lived in a scratch directory and would have been lost. Meanwhile `tests/e2e/christmas-shapes.test.ts` has referenced `docs/technical/AUTOMATED_TESTING.md` since it was written, and that file never existed.

**2. `.claude/` was showing as untracked.** It holds the personal permission allowlist (machine-specific absolute paths) and a runtime lock that churns every session.

## What

### E2E suite, documented and committed

- **`docs/technical/AUTOMATED_TESTING.md`** — the missing file. Covers setup, the preview SSO bypass, how the scripts drive the app via the hidden test-controls block in `CreateClient.tsx`, and what it would take to wire this into CI.
- **`tests/e2e/preview-smoke.mjs`** — 26 checks: pages return 200 and render, no console errors or page exceptions, the create wizard runs through shape extraction to Leaflet mounting, one API call. Fast, no external quota.
- **`tests/e2e/preview-share-flow.mjs`** — full journey to a generated route and the share modal. Asserts the four brand icons now shipped from `BrandIcons.tsx` render with correct geometry; a missing icon fails *silently* at zero size, so presence alone proves nothing.

Playwright is deliberately **not** a devDependency — it is large and CI does not run these. The doc covers installing it on demand.

The doc also records two traps that produced false failures while writing the suite, both caught only by baselining against production first:

- Next.js embeds its 404 template in the RSC flight payload of every healthy page, so matching raw HTML reports a false failure on every route.
- Leaflet only mounts from wizard step 2 — asserting `.leaflet-container` on a fresh `/en/create` always fails.

`TESTING_STRATEGY.md` Layer 4 is updated too; its "Cursor browser tools (not Playwright/Puppeteer)" note is now out of date.

### gitignore

```
.claude/settings.local.json
.claude/*.lock
tests/e2e/*.png
```

Scoped so a shared `.claude/settings.json` stays committable. Verified both `.claude` files match and `settings.json` does not.

## Verification

Both scripts run green from their committed paths against production — 26/26 for the smoke suite, and all four brand icons correct in the share flow. `npm run lint` exits 0 and vitest still collects 19 files / 301 tests, confirming the `.mjs` scripts aren't picked up as test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)