### PR TITLE
chore(deps): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint-plugin-security": "^4.0.0",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4",
-        "typescript": "^5",
+        "typescript": "^6",
         "vitest": "^4.0.13"
       }
     },
@@ -10961,9 +10961,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint-plugin-security": "^4.0.0",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4",
-        "typescript": "^6",
+        "typescript": "~6.0.3",
         "vitest": "^4.0.13"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",
-    "typescript": "^5",
+    "typescript": "^6",
     "vitest": "^4.0.13"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",
-    "typescript": "^6",
+    "typescript": "~6.0.3",
     "vitest": "^4.0.13"
   },
   "overrides": {


### PR DESCRIPTION
## Why not TypeScript 7?

Dependabot proposed TS 7.0.2 in #82. That PR was closed as unmergeable — and it is genuinely blocked, not misconfigured:

- `typescript-eslint`, `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` each **hard-`throw` at module load** on `versionMajor >= 7`. There is no env var or option to bypass it.
- Even `typescript-eslint@canary` (`8.65.1-alpha.7`) still declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"`.
- Upstream tracking issue: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) targets TS >=7.1.

TS 7 is the native/Go port, which is why the JS API story is still unsettled — the thrown error itself suggests running side-by-side with the TS 6 API.

## Why TypeScript 6 instead

`6.0.3` is stable and sits **inside** typescript-eslint's `<6.1.0` ceiling, so it lands a full major version now with no patches, no overrides and no pinned prereleases.

## Verification (run locally against 6.0.3 before pushing)

| Check | Result |
|---|---|
| `tsc --noEmit` | 0 errors |
| `eslint` | clean (83 files) |
| `vitest run` | 301 passed, 2 skipped |
| `next build` | succeeds, full route manifest |
| `npm ci` | lockfile coherent |

Leaves the door open to 7.x once typescript-eslint ships support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript development tooling to the latest major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->