### PR TITLE
fix(deps): patch fast-uri and brace-expansion to unblock deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4265,9 +4265,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6879,9 +6879,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7203,9 +7203,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## What & why

A Vercel "error deploying to the preview environment" email traced to a dependency advisory, not a code change. The `prebuild` npm hook runs `npm audit --audit-level=high --omit=dev` **before** `next build` — and since Vercel builds via `npm run build`, that audit gates **every** deploy (preview and production). The same command is also the blocking step in the `security` CI workflow.

Two newly-disclosed **production** high-severity advisories were failing that audit:

| Package | Was → Now | Advisory | Pulled in via |
|---|---|---|---|
| `fast-uri` | 3.1.4 → 3.1.5 | GHSA-7p8r-x3mc-p8w7 | `ajv` |
| `brace-expansion` | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 | `glob` |

The email fired on Dependabot PR #94's preview — but #94 had already patched `brace-expansion`, leaving only `fast-uri` there. `main` has **both**, so it also blocks production deploys and the `security` job. This PR fixes both at the source.

## The change

- **`package-lock.json` only** — in-range patch bumps (both consumers already allow the patched versions: `ajv` requires `fast-uri@^3.0.1`; the affected `brace-expansion` stays on `^5`). No `package.json` change.

## Verification

- ✅ `npm audit --audit-level=high --omit=dev` → **0 vulnerabilities** (was exit 1 — the actual deploy/CI blocker)
- ✅ Both integrity hashes recomputed independently from the published tarballs
- ✅ `npm ci` with **npm 11** (the CI/Vercel toolchain) succeeds — lockfile fully consistent
- ✅ `npm run lint` clean

Once merged this unblocks production deploys, clears the default-branch Dependabot alert, and unblocks the open Dependabot PRs (#92/#93/#94) after they pick up the fixed base.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UwtondhEoPUXioeKBugYX)_