### PR TITLE
fix(test): poll for the drawn route in the river crossing check

### DIFF
--- a/tests/e2e/river-crossing-visual.mjs
+++ b/tests/e2e/river-crossing-visual.mjs
@@ -114,14 +114,39 @@ try {
 
     // The route has to be drawn, not merely computed. React-Leaflet may use
     // either the SVG or the canvas renderer, so accept both.
-    const drawn = await page.evaluate(() => {
-        const map = document.querySelector('.leaflet-container');
-        if (!map) return { paths: 0, canvases: 0 };
-        return {
-            paths: map.querySelectorAll('svg path').length,
-            canvases: map.querySelectorAll('canvas').length,
-        };
-    });
+    //
+    // Poll rather than sample once. `has-route` flips as soon as the route is in
+    // state, but ResultMap keys itself on the centre and so re-mounts while
+    // MapUpdater refits the bounds, leaving the overlay pane briefly empty. A
+    // single evaluate() lands in that gap and reports a route that is plainly on
+    // screen as missing.
+    const countDrawn = () =>
+        page.evaluate(() => {
+            const map = document.querySelector('.leaflet-container');
+            if (!map) return { paths: 0, canvases: 0 };
+            return {
+                paths: map.querySelectorAll('svg path').length,
+                canvases: map.querySelectorAll('canvas').length,
+            };
+        });
+
+    try {
+        await page.waitForFunction(
+            () => {
+                const map = document.querySelector('.leaflet-container');
+                if (!map) return false;
+                return (
+                    map.querySelectorAll('svg path').length > 0 ||
+                    map.querySelectorAll('canvas').length > 0
+                );
+            },
+            { timeout: 30_000 }
+        );
+    } catch {
+        // Swallow the timeout so the counts below report what was actually
+        // there and the remaining checks still run.
+    }
+    const drawn = await countDrawn();
     check(
         'route drawn on the map',
         drawn.paths > 0 || drawn.canvases > 0,

--- a/tests/e2e/river-crossing-visual.mjs
+++ b/tests/e2e/river-crossing-visual.mjs
@@ -18,7 +18,7 @@
  * Exits 0 when every check passes, 1 otherwise.
  */
 
-import { chromium } from 'playwright';
+import { chromium, errors } from 'playwright';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -142,9 +142,13 @@ try {
             },
             { timeout: 30_000 }
         );
-    } catch {
-        // Swallow the timeout so the counts below report what was actually
-        // there and the remaining checks still run.
+    } catch (error) {
+        // A timeout means the overlay genuinely never appeared: fall through so
+        // the counts below report what was actually there and the remaining
+        // checks still run. Anything else — a detached frame, an evaluation
+        // fault — is a real error, and reporting it as "0 svg paths" would hide
+        // the cause behind the same misleading result this check used to give.
+        if (!(error instanceof errors.TimeoutError)) throw error;
     }
     const drawn = await countDrawn();
     check(


### PR DESCRIPTION
## Problem

`tests/e2e/river-crossing-visual.mjs` has always false-failed its `route drawn on the map` check — on **every** environment, including production.

Surfaced while running the e2e suite against the PR #96 preview: 6/7 checks passed, but `route drawn on the map — 0 svg path(s), 0 canvas(es)` failed, even though the screenshot the script saves moments later clearly shows the route drawn.

## Root cause

The assertion sampled the DOM exactly once, the instant `has-route` flipped to `true`:

- `ResultMap.tsx:69` keys the `MapContainer` on the map centre, so it **re-mounts** when `MapUpdater` refits the bounds to the freshly generated route.
- During that re-mount the Leaflet overlay pane is empty.
- The single `evaluate()` landed in that gap and reported 0 paths.

The script's own `waitForTimeout(4000)` before the screenshot is precisely why the picture succeeds where the assertion fails.

## Fix

Wait for the overlay to appear before counting, instead of sampling once. The timeout is swallowed deliberately so a genuine failure still reports the real counts and the remaining checks (accuracy, length, GPX) keep running rather than being skipped by the outer `catch`.

## Verification

Run against production, which reproduced the failure identically before the change:

| | before | after |
|---|---|---|
| `route drawn on the map` | ❌ 0 svg path(s), 0 canvas(es) | ✅ 4 svg path(s), 0 canvas(es) |
| total | 6 passed, 1 failed | **7 passed, 0 failed** |

Pre-push checks all green: `npm audit --audit-level=high --omit=dev` (0 vulns), `npm run lint`, `npm test` (506 passed / 50 skipped), `npx tsc --noEmit`.

Test-only change — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved route-rendering checks by allowing visual elements more time to appear.
  * Ensured subsequent validation steps continue even when rendering times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->