### PR TITLE
fix(test): point the Seine control at the Seine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ test_output*.txt
 
 # e2e run artifacts (screenshots written beside the scripts)
 tests/e2e/*.png
+
+# Scenario matrix output: a screenshot pair per case plus results-<label>.json,
+# written by river-crossing-matrix.mjs. Regenerated per run, never reviewed.
+tests/e2e/matrix/

--- a/tests/e2e/river-crossing-matrix.mjs
+++ b/tests/e2e/river-crossing-matrix.mjs
@@ -25,7 +25,7 @@
  * Each case generates a real route, so this consumes Radar quota.
  */
 
-import { chromium } from 'playwright';
+import { chromium, errors } from 'playwright';
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -189,13 +189,29 @@ async function runCase(page, testCase) {
 
     if (testCase.search) {
         if (!testCase.expect) {
-            throw new Error(`case "${testCase.id}" has a search but no expect — see the note below`);
+            throw new Error(
+                `case "${testCase.id}" has a search but no expect: give it the substring the ` +
+                    `chosen autocomplete suggestion must contain`
+            );
         }
         const search = 'input[placeholder^="Search location"]';
         await page.click(search);
         await page.fill(search, testCase.search);
-        // Autocomplete is debounced and goes through the Radar proxy.
-        await page.waitForSelector('.absolute.top-full button', { timeout: 30_000 });
+
+        // Autocomplete is debounced and goes through the Radar proxy. The
+        // dropdown is gated on `suggestions.length > 0` in AreaSelector.tsx, so
+        // an empty result never renders and lands here rather than falling
+        // through to the match check — which is also how the 10 req/min limit
+        // shows up mid-matrix.
+        try {
+            await page.waitForSelector('.absolute.top-full button', { timeout: 30_000 });
+        } catch (error) {
+            if (!(error instanceof errors.TimeoutError)) throw error;
+            throw new Error(
+                `"${testCase.search}" returned no autocomplete suggestion within 30s — ` +
+                    `Radar may be rate limiting, so retry this case with MATRIX_ONLY=${testCase.id}`
+            );
+        }
 
         // Pick the suggestion by name, never by position. Radar ranked a hamlet
         // called Paris in Castillonnès above the capital, so taking the first
@@ -209,7 +225,7 @@ async function runCase(page, testCase) {
         if (index === -1) {
             throw new Error(
                 `"${testCase.search}" offered no suggestion matching "${testCase.expect}" — ` +
-                    `got: ${offered.join(' | ') || '(none)'}`
+                    `got: ${offered.join(' | ')}`
             );
         }
         await options.nth(index).click();

--- a/tests/e2e/river-crossing-matrix.mjs
+++ b/tests/e2e/river-crossing-matrix.mjs
@@ -45,6 +45,11 @@ if (!baseUrl || !label) {
 /**
  * The cases worth looking at. `search` is left out for London so the wizard's
  * own default centre is used — 51.505,-0.09 is the reported case exactly.
+ *
+ * Every case that does search must also carry `expect`: a substring the chosen
+ * autocomplete suggestion has to contain. Radar's ranking is not stable enough
+ * to trust by position, and a case that quietly lands in the wrong place still
+ * produces a length and an accuracy, so it reads as a result rather than a bug.
  */
 const CASES = [
     {
@@ -72,7 +77,10 @@ const CASES = [
         id: '4-heart-paris-walk',
         title: 'Heart over the Seine, walking — control, already worked',
         shape: 'heart',
-        search: 'Paris, France',
+        // "Paris, France" ranks a hamlet called Paris in Castillonnès above the
+        // capital; naming the region puts the real one first. See `expect`.
+        search: 'Paris, Île-de-France, France',
+        expect: 'IDF',
         radius: 1000,
         mode: 'Walk',
     },
@@ -81,6 +89,7 @@ const CASES = [
         title: 'Heart over Madrid, walking — control, no river',
         shape: 'heart',
         search: 'Madrid, Spain',
+        expect: 'MD ES',
         radius: 1000,
         mode: 'Walk',
     },
@@ -89,6 +98,7 @@ const CASES = [
         title: 'Heart over Amsterdam, walking — control, canals everywhere',
         shape: 'heart',
         search: 'Amsterdam, Netherlands',
+        expect: 'NH NL',
         radius: 1000,
         mode: 'Walk',
     },
@@ -97,6 +107,7 @@ const CASES = [
         title: 'Heart over Warsaw at 4500 m, walking — the reported spur case',
         shape: 'heart',
         search: 'Warsaw, Poland',
+        expect: 'Mazovia',
         radius: 4500,
         mode: 'Walk',
     },
@@ -105,6 +116,7 @@ const CASES = [
         title: 'Heart over Warsaw at 1500 m, walking — where the cleanup helps most',
         shape: 'heart',
         search: 'Warsaw, Poland',
+        expect: 'Mazovia',
         radius: 1500,
         mode: 'Walk',
     },
@@ -176,12 +188,31 @@ async function runCase(page, testCase) {
     });
 
     if (testCase.search) {
+        if (!testCase.expect) {
+            throw new Error(`case "${testCase.id}" has a search but no expect — see the note below`);
+        }
         const search = 'input[placeholder^="Search location"]';
         await page.click(search);
         await page.fill(search, testCase.search);
         // Autocomplete is debounced and goes through the Radar proxy.
         await page.waitForSelector('.absolute.top-full button', { timeout: 30_000 });
-        await page.locator('.absolute.top-full button').first().click();
+
+        // Pick the suggestion by name, never by position. Radar ranked a hamlet
+        // called Paris in Castillonnès above the capital, so taking the first
+        // entry ran the Seine control over farmland 500 km away — and reported
+        // its 48% as a routing result rather than a broken case. Matching on
+        // `expect` turns that class of miss into a loud failure.
+        const options = page.locator('.absolute.top-full button');
+        const offered = await options.allInnerTexts();
+        const wanted = testCase.expect.toLowerCase();
+        const index = offered.findIndex(text => text.toLowerCase().includes(wanted));
+        if (index === -1) {
+            throw new Error(
+                `"${testCase.search}" offered no suggestion matching "${testCase.expect}" — ` +
+                    `got: ${offered.join(' | ') || '(none)'}`
+            );
+        }
+        await options.nth(index).click();
         await page.waitForTimeout(2500);
     }
 


### PR DESCRIPTION
## The bug

`river-crossing-matrix.mjs` clicked the **first** autocomplete suggestion. Radar ranks a hamlet called *Paris* in the commune of Castillonnès (47330, Lot-et-Garonne) above the capital:

```
query "Paris, France"
  0 | Paris, 47330 Castillonnès, FR | 44.62876  0.61758   <- what the matrix picked
  1 | Paris, IDF FR                 | 48.85341  2.34880   <- the actual Seine
```

So case 4 — titled *"Heart over the Seine, walking — control, already worked"* — had been generating routes over farmland ~500 km from any Seine. The Seine control was never exercised.

**Why it went unnoticed:** a wrong-place run still produces a length and an accuracy, so it reads as a poor routing result rather than a broken case. It reported **13.47 km at 48%** — and 48% happens to match the rural Castillonnès figure documented in `SPUR_CLEANUP.md:210` as an accepted spur-cleanup trade-off, which made the wrong number look expected.

Verified the other three searching cases (Madrid, Amsterdam, Warsaw) already resolve correctly first — Paris was the only one.

## The fix

1. **Name the region** in the query so the capital ranks first.
2. **Stop trusting position.** Every case with `search` now carries `expect`, a substring the chosen suggestion must contain. Selection is by match, and a miss throws with the full list of what was offered — turning this class of silent mis-geocode into a loud failure.

## Result

| case 4 | before | after |
|---|---|---|
| location | farmland nr. Castillonnès | Île de la Cité, 1er–6e Arr. |
| length / accuracy | 13.47 km / 48% | **14.84 km / 79%** |

## Verification (against production)

- Case 4 now renders over the actual Seine — arrondissements, Marais, Bastille visible.
- Failure path exercised deliberately with an unmatchable `expect`:
  `"Amsterdam, Netherlands" offered no suggestion matching "ZZ-NOT-A-PLACE" — got: Amsterdam, NH NL`
- `npm test` 506 passed / 50 skipped, `lint`, `tsc --noEmit`, `audit --omit=dev` 0 vulns.

Also gitignores `tests/e2e/matrix/` — per-case screenshots and `results-<label>.json`, regenerated every run and never reviewed.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autocomplete validation in location searches by selecting suggestions that match the expected location text.
  - Searches now report available suggestions when no matching result is found, making failures clearer.

- **Tests**
  - Expanded end-to-end coverage for region-qualified and city-specific searches, including Paris, Madrid, Amsterdam, and Warsaw.
  - Generated test artifacts are now excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->